### PR TITLE
Fixed typo on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
             <p class="center">
                 UI-Utils is a FabricMC Minecraft mod made by Coderx-Gamer and MrBreakNFix, that adds multiple features to Minecraft GUI(s,) making it
                 useful for debugging plugins and dupe hunting on servers. This mod is always updated to the latest stable
-                version of Minecraft, While it primarily supported on most Linux
-                distributions, and OSX compatibility is not guaranteed.
+                version of Minecraft. While it primarily supported on most Linux
+                distributions, OSX compatibility is not guaranteed.
             </p>
         </div>
         <div class="vertical-space"></div>


### PR DESCRIPTION
While the front page used to say:
`This mod is always updated to the latest stable version of Minecraft, While it primarily supported on most Linux distributions, and OSX compatibility is not guaranteed.`

it now says:
`This mod is always updated to the latest stable version of Minecraft. While it primarily supported on most Linux distributions,  OSX compatibility is not guaranteed.`